### PR TITLE
Removed  ispapp-lan, dhcp-server, ip firewall nat masquerade, interface bridge port and hidden SSIDs.

### DIFF
--- a/ispapp.rsc
+++ b/ispapp.rsc
@@ -133,7 +133,7 @@ foreach j in=[/system script job find] do={
 }
 :global topKey "#####HOST_KEY#####";
 :global topDomain "#####DOMAIN#####";
-:global topClientInfo "RouterOS-v2.05";
+:global topClientInfo "RouterOS-v2.06";
 :global topListenerPort "8550";
 :global topServerPort "443";
 :global topSmtpPort "8465";
@@ -1914,57 +1914,10 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n\r\
     \n    #:put \"wireless mode: \$mode with WAN interface: \$wanport\";\r\
     \n\r\
-    \n     # add bridge\r\
-    \n     if ([:len [/interface bridge find name=\"ispapp-lan\"]] = 0) do={\r\
-    \n       /interface bridge add name=\"ispapp-lan\";\r\
-    \n      #:put \"created ispapp-lan bridge\";\r\
-    \n    } else={\r\
-    \n      #:put \"ispapp-lan bridge is already created\";\r\
-    \n    }\r\
-    \n\r\
     \n    # remove existing ispapp configurations\r\
     \n    # dhcp server, ip pool, ip address, nat rule\r\
     \n    :do {\r\
-    \n       /interface wireless security-profiles remove ispapp-hidden;\r\
-    \n     } on-error={\r\
-    \n     }\r\
-    \n    :do {\r\
-    \n      /ip firewall nat remove [find comment=ispapp-lan];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      /ip firewall nat remove [find comment=ispapp-wifi];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      /ip dhcp-server remove [find interface=ispapp-lan];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
     \n      /ip dhcp-server remove [find interface=ispapp-wifi];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      if ([/system package get ipv6 disabled] = false) do={\r\
-    \n        # routeros scripts cannot have an IPv6 command if the IPv6 package is not installed\r\
-    \n        # create a new script\r\
-    \n        :local ipv6disablescript \"/ipv6 nd remove [find interface=ispapp-lan];\";\r\
-    \n        /file print file=\"ispapp-ipv6-disable.rsc\" where name=\"\";\r\
-    \n        /file set \"ispapp-ipv6-disable.rsc\" contents=\$ipv6disablescript;\r\
-    \n        /import \"ispapp-ipv6-disable.rsc\";\r\
-    \n      }\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      /ip dhcp-server network remove [find gateway=10.10.0.1];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      /ip dhcp-server network remove [find gateway=10.11.0.1];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
-    \n      /ip pool remove ispapp-lan-pool;\r\
     \n    } on-error={\r\
     \n    }\r\
     \n    :do {\r\
@@ -1972,45 +1925,9 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n    } on-error={\r\
     \n    }\r\
     \n    :do {\r\
-    \n      /ip address remove [find interface=ispapp-lan];\r\
-    \n    } on-error={\r\
-    \n    }\r\
-    \n    :do {\r\
     \n      /ip address remove [find interface=ispapp-wifi];\r\
     \n    } on-error={\r\
     \n    }\r\
-    \n\r\
-    \n    if (\$mode = \"ap_router\") do={\r\
-    \n\r\
-    \n      #:put \"WAN <> ispapp-lan with NAT\";\r\
-    \n      :local ipPre \"10.10\";\r\
-    \n      if ([:find \$wanIP \$ipPre] = 0) do={\r\
-    \n        :set ipPre \"10.11\";\r\
-    \n      }\r\
-    \n      /ip address add interface=ispapp-lan address=(\$ipPre . \".0.1/16\");\r\
-    \n      /ip pool add ranges=(\$ipPre . \".0.10-10.10.254.254\") name=ispapp-lan-pool;\r\
-    \n      /ip dhcp-server network add address=(\$ipPre . \".0.0/16\") dns-server=8.8.8.8,8.8.4.4 gateway=(\$ipPre . \".0.1\")\r\
-    \n      /ip dhcp-server add interface=ispapp-lan address-pool=ispapp-lan-pool disabled=no;\r\
-    \n      /ip firewall nat add action=masquerade chain=srcnat comment=ispapp-lan\r\
-    \n\r\
-    \n      :do {\r\
-    \n        # add IPv6 if the routeros package exists, if there is a dhcp-client nd will provide addresses to ispapp-lan\r\
-    \n        if ([/system package get ipv6 disabled] = false) do={\r\
-    \n          # routeros scripts cannot have an IPv6 command if the IPv6 package is not installed\r\
-    \n          # create a new script\r\
-    \n          :local ipv6enablescript \"/ipv6 nd add hop-limit=64 interface=ispapp-lan ra-interval=20s-1m;\";\r\
-    \n          /file print file=\"ispapp-ipv6-enable.rsc\" where name=\"\";\r\
-    \n          /file set \"ispapp-ipv6-enable.rsc\" contents=\$ipv6enablescript;\r\
-    \n          /import \"ispapp-ipv6-enable.rsc\";\r\
-    \n        }\r\
-    \n      } on-error={\r\
-    \n      }\r\
-    \n\r\
-    \n   } else={\r\
-    \n     :log info (\"\\nMake sure the WAN port is in the 'ispapp-lan' bridge.\\n/interface bridge port add bridge=ispapp-lan interface=wan0\");\r\
-    \n   }\r\
-    \n\r\
-    \n   :log info (\"Add the LAN ports to the ispapp-lan bridge if you want those on the ISPApp LAN.\");\r\
     \n\r\
     \n  if (\$hasWirelessInterfaces = \"1\" && [:len \$configuredSsids] > 0) do={\r\
     \n    # this device has wireless interfaces\r\
@@ -2029,7 +1946,7 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n\r\
     \n     }\r\
     \n\r\
-    \n     # remove existing ispapp vaps and bridge ports\r\
+    \n     # remove existing ispapp vaps\r\
     \n     :foreach wIfaceId in=[/interface wireless find] do={\r\
     \n\r\
     \n        :local wIfName ([/interface wireless get \$wIfaceId name]);\r\
@@ -2037,18 +1954,8 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n        :local isIspappIf ([:find \$wIfName \"ispapp-\"]);\r\
     \n        :local wIfType ([/interface wireless get \$wIfaceId interface-type]);\r\
     \n\r\
-    \n        if (\$wIfType != \"virtual\") do={\r\
-    \n          :do {\r\
-    \n            # try to remove the bridge port\r\
-    \n            /interface bridge port remove [find interface=\$wIfName];\r\
-    \n          } on-error={\r\
-    \n            # no bridge port\r\
-    \n          }\r\
-    \n        }\r\
-    \n\r\
     \n        if (\$isIspappIf = 0) do={\r\
     \n          #:put \"deleting virtual ispapp interface: \$wIfName\";\r\
-    \n          /interface bridge port remove [find interface=\$wIfName];\r\
     \n          /interface wireless remove \$wIfName;\r\
     \n        } else={\r\
     \n\r\
@@ -2161,7 +2068,6 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n            }\r\
     \n\r\
     \n            /interface wireless enable \$wIfName;\r\
-    \n            /interface bridge port add bridge=ispapp-lan interface=\"\$wIfName\";\r\
     \n          } else={\r\
     \n            # create a virtual interface for any ssids after the first\r\
     \n            if (\$authenticationtypes = \"none\") do={\
@@ -2170,7 +2076,6 @@ add dont-require-permissions=no name=ispappConfig owner=admin policy=ftp,reboot,
     \n              /interface wireless add master-interface=\"\$wIfName\" ssid=\"\$ssid\" name=\"ispapp-\$ssid-\$wIfName\" security-profile=\"ispapp-\$ssid-\$wIfName\" wireless-protocol=802.11 frequency=auto mode=ap-bridge;\r\
     \n            }\r\
     \n            /interface wireless enable \"ispapp-\$ssid-\$wIfName\";\r\
-    \n            /interface bridge port add bridge=ispapp-lan interface=\"ispapp-\$ssid-\$wIfName\";\r\
     \n          }\r\
     \n        }\r\
     \n\r\


### PR DESCRIPTION
Remove these parts of the RouterOS client script:
virtual access points, 
hidden SSIDs,
interface bridge ispapp-lan,
interface bridge port,
ip address 10.10.0.1/16,
ip dhcp-server,
ip dhcp-server network,
ip pool ispapp-lan-pool,
ip firewall nat masquerade.